### PR TITLE
Simplify continue as new logic.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,8 @@ services:
       - ES_VERSION=v7
       - PROMETHEUS_ENDPOINT=0.0.0.0:8000
     image: temporalio/auto-setup:1.14.0
+    ports:
+      - 7233:7233
   temporal-admin-tools:
     depends_on:
       - temporal

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,6 +1,3 @@
-import type { ExternalWorkflowHandle } from '@temporalio/workflow/lib/workflow-handle'
-import { defineSignal } from '@temporalio/workflow'
-
 const VERSION = 'v0.8'
 
 export const DEFAULT_TASK_QUEUE = `url-scraper-${VERSION}`
@@ -16,26 +13,6 @@ export const getBatchProcessorWorkflowId = (batchId: number) => `batch-processor
 // TODO: Apply transformation on url to normalise it etc
 export const getScrapedUrlStateWorkflowId = (url: string) => `scraped-url-state-${VERSION}:${url}`
 
-const pingWorkflowSignal = defineSignal('internal_pingWorkflowSignal')
-
-type ExternalWorkflowHandleError = Error & {
-  type: 'ExternalWorkflowExecutionNotFound'
-}
-
-export async function isExternalWorkflowRunning(handle: Pick<ExternalWorkflowHandle, 'signal'>): Promise<boolean> {
-  try {
-    await handle.signal(pingWorkflowSignal)
-  } catch (error) {
-    const isWorkflowNotRunningError =
-      (error as ExternalWorkflowHandleError).type === 'ExternalWorkflowExecutionNotFound'
-
-    if (isWorkflowNotRunningError) {
-      return false
-    }
-
-    // Unexpected error
-    throw error
-  }
-
-  return true
+export type TemporalGRPCError = Error & {
+  code: number
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -7,6 +7,7 @@ export const BATCH_ID_ASSIGNER_SINGLETON_WORKFLOW_ID = `batch-id-assigner-workfl
 // Time unit accepted by https://www.npmjs.com/package/ms
 export const SCRAPE_INTERVAL = '10s'
 export const MAX_BATCH_SIZE = 2
+export const CONTINUE_AS_NEW_THRESHOLD = '1 day'
 
 export const getBatchProcessorWorkflowId = (batchId: number) => `batch-processors-${VERSION}:${batchId}`
 

--- a/src/workflows/batch-id-assigner-singleton.workflow/batch-id-assigner-singleton.workflow.ts
+++ b/src/workflows/batch-id-assigner-singleton.workflow/batch-id-assigner-singleton.workflow.ts
@@ -1,25 +1,23 @@
-import { getScrapedUrlStateWorkflowId, isExternalWorkflowRunning, MAX_BATCH_SIZE } from '../../shared'
+import { getScrapedUrlStateWorkflowId, MAX_BATCH_SIZE } from '../../shared'
 import { assignToBatchSignal, batchIdAssignedSignal, BatchIdAssignedSignalPayload, newGapSignal } from '../../signals'
 import {
   continueAsNew,
   getExternalWorkflowHandle,
   setHandler,
-  sleep,
   proxyActivities,
   condition
 } from '@temporalio/workflow'
-import ms from 'ms'
 import { useBatchIsGapsState } from './batch-id-gaps.state'
 import { getBatchIdGapsQuery } from '../../queries'
 import type * as activities from '../../activities'
+
+const MAX_ITERATIONS = 1000
 
 const { ensureBatchProcessorWorkflowForURL: ensureBatchProcessorWorkflowForURLActivity } = proxyActivities<
   typeof activities
 >({
   startToCloseTimeout: '1 minute'
 })
-
-// We want this as large as possible. TODO: document tradeoffs & heuristics to estimate it's max
 
 interface Payload {
   initialState?: {
@@ -33,7 +31,6 @@ export async function batchIdAssignerSingletonWorkflow({ initialState }: Payload
 
   setHandler(getBatchIdGapsQuery, () => batchIdToNumberOfGaps)
 
-  let numberOfUrlsHandled = 0
   let numberOfUrlsInCurrentBatch = initialState?.numberOfUrlsInCurrentBatch ?? 0
   let currentBatchId: number = initialState?.currentBatchId ?? 0
 
@@ -62,19 +59,17 @@ export async function batchIdAssignerSingletonWorkflow({ initialState }: Payload
   const notifyStateWorkflowWithItsNewBatchId = async ({ url, batchId }: BatchIdAssignedSignalPayload) => {
     const handle = getExternalWorkflowHandle(getScrapedUrlStateWorkflowId(url))
 
-    if (!(await isExternalWorkflowRunning(handle))) {
-      console.log(`⚠️ failed to notify state workflow as it doesnt exist`)
+    return handle.signal(batchIdAssignedSignal, {
+        batchId,
+        url
+    })  
+  }
 
+  const assignToBatchSignalHandler = async (url: string | undefined) => {
+    if (!url) {
       return
     }
 
-    await handle.signal(batchIdAssignedSignal, {
-      batchId,
-      url
-    })
-  }
-
-  const assignToBatchSignalHandler = async (url: string) => {
     console.log('requested new batch ID', url)
 
     const nextBatchId = getNextBatchId()
@@ -82,13 +77,16 @@ export async function batchIdAssignerSingletonWorkflow({ initialState }: Payload
     console.log('next batch id', { url, nextBatchId })
 
     await ensureBatchProcessorWorkflowForURLActivity({ url, batchId: nextBatchId })
-
-    await notifyStateWorkflowWithItsNewBatchId({
-      url,
-      batchId: nextBatchId
-    })
-
-    console.log('notified state workflow with new batch id', { url, nextBatchId })
+    
+    try {
+      await notifyStateWorkflowWithItsNewBatchId({
+        url,
+        batchId: nextBatchId
+      })
+    } catch (error) {
+      // TODO: Unregister URL from batch here as compensation?
+      console.log('⚠️ failed to signal state workflow', { error, url })
+    }
   }
 
   const urlsToAssign: string[] = []
@@ -99,31 +97,21 @@ export async function batchIdAssignerSingletonWorkflow({ initialState }: Payload
 
   setHandler(newGapSignal, ({ batchId }) => incNumberOfGaps(batchId))
 
-  // Run forever (is there a better way of doing this in Temporal?)
-  while (true) {
+  // Loop for MAX_ITERATIONS or after we've received no signals for a day, whichever is sooner.
+  // We continue as new if we've been inactive for a day to aid in the cleanup of old code versions.
+  for (let iteration = 1; iteration <= MAX_ITERATIONS; ++iteration) {
+    await condition(() => urlsToAssign.length > 0, '1 day')
+
     while (urlsToAssign.length > 0) {
       const nextUrlToAssign = urlsToAssign.shift()
-
-      if (!nextUrlToAssign) {
-        break
-      }
-
       await assignToBatchSignalHandler(nextUrlToAssign)
-      numberOfUrlsHandled += 1
     }
-
-    const shouldContinueAsNew = numberOfUrlsHandled === 1000
-
-    if (shouldContinueAsNew) {
-      await continueAsNew<typeof batchIdAssignerSingletonWorkflow>({
-        initialState: {
-          currentBatchId,
-          numberOfUrlsInCurrentBatch
-        }
-      })
-    }
-
-    // Run forever (is there a better way of doing this in Temporal?) @Roey
-    await condition(() => urlsToAssign.length > 0, ms('100000days'))
   }
+
+  await continueAsNew<typeof batchIdAssignerSingletonWorkflow>({
+    initialState: {
+      currentBatchId,
+      numberOfUrlsInCurrentBatch
+    }
+  })
 }

--- a/src/workflows/scraped-url-state.workflow.ts
+++ b/src/workflows/scraped-url-state.workflow.ts
@@ -2,7 +2,6 @@ import { condition, getExternalWorkflowHandle, setHandler } from '@temporalio/wo
 
 import { BATCH_ID_ASSIGNER_SINGLETON_WORKFLOW_ID, getBatchProcessorWorkflowId } from '../shared'
 import { batchIdAssignedSignal, assignToBatchSignal, stopScrapingUrlSignal } from '../signals'
-import ms from 'ms'
 
 interface Payload {
   url: string


### PR DESCRIPTION
Also avoid checking for workflow presence ahead of time. Simply send attempt to send a signal and handle any errors.